### PR TITLE
Remove unused address

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,4 @@ Just on Firebase for now.
 
 ## Whitelisted Addresses
 
-The following addresses have been given access to the `cors-public-server` on Firebase:
-
-+ `https://littlemomster.be` for @dboute
+No addresses have been added yet. If you would like to add yours, open an issue on this repo.

--- a/functions/index.js
+++ b/functions/index.js
@@ -6,7 +6,7 @@ const corsServer = corsAnywhere.createServer({
     originWhitelist: [
       'http://localhost:3000',
       'http://localhost:5000',
-      'https://littlemomster.be', // for GitHub user @dboute
+      'https://your-website.com',
     ],
     requireHeader: ['origin', 'x-requested-with'],
     removeHeaders: ['cookie', 'cookie2']

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cors-public-server",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cors-public-server",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "cors-anywhere": "^0.4.4",
         "firebase-admin": "^11.0.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cors-public-server",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A server implementing the cors-anywhere node package",
   "scripts": {
     "serve": "firebase emulators:start --only functions",


### PR DESCRIPTION
Remove the only address on the `originWhitelist` as it's now redundant. The user @dboute managed to host their own in the end. Add a generic address back for illustrative purposes.

Update `README.md` to reflect the above.